### PR TITLE
Fix File Type Factory for libsonnet

### DIFF
--- a/src/main/java/com/jsonnetplugin/JsonnetFileTypeFactory.java
+++ b/src/main/java/com/jsonnetplugin/JsonnetFileTypeFactory.java
@@ -6,7 +6,8 @@ import org.jetbrains.annotations.NotNull;
 public class JsonnetFileTypeFactory extends FileTypeFactory {
     @Override
     public void createFileTypes(@NotNull FileTypeConsumer fileTypeConsumer) {
-        fileTypeConsumer.consume(JsonnetFileType.INSTANCE, "jsonnet;libsonnet");
+        fileTypeConsumer.consume(JsonnetFileType.INSTANCE, "jsonnet");
+        fileTypeConsumer.consume(JsonnetFileType.INSTANCE, "libsonnet");
         fileTypeConsumer.consume(JsonnetFileType.INSTANCE, new FileNameMatcher() {
             @Override
             public boolean accept(@NotNull String fileName) {


### PR DESCRIPTION
With this fix, both jsonnet and libsonnet are working within the plugin.
Built and tested locally.